### PR TITLE
Some very first testing

### DIFF
--- a/src/Npgsql/ClusterStateCache.cs
+++ b/src/Npgsql/ClusterStateCache.cs
@@ -43,10 +43,11 @@ namespace Npgsql
         {
             internal readonly ClusterState State;
             internal readonly NpgsqlTimeout Timeout;
-            // While the TimeStamp is not strictly required, it does lowers the risk of overwriting the current state with an old value
+            // While the TimeStamp is not strictly required, it does lower the risk of overwriting the current state with an old value
             internal readonly DateTime TimeStamp;
 
-            public ClusterInfo(ClusterState state, NpgsqlTimeout timeout, DateTime timeStamp) => (State, Timeout, TimeStamp) = (state, timeout, timeStamp);
+            public ClusterInfo(ClusterState state, NpgsqlTimeout timeout, DateTime timeStamp)
+                => (State, Timeout, TimeStamp) = (state, timeout, timeStamp);
         }
     }
 
@@ -56,6 +57,6 @@ namespace Npgsql
         Offline = 1,
         PrimaryReadWrite = 2,
         PrimaryReadOnly = 3,
-        Secondary = 4
+        Standby = 4
     }
 }

--- a/src/Npgsql/ConnectorPool.cs
+++ b/src/Npgsql/ConnectorPool.cs
@@ -310,8 +310,8 @@ namespace Npgsql
                 {
                     // We've managed to increase the open counter, open a physical connections.
                     var connector = new NpgsqlConnector(conn, this) { ClearCounter = _clearCounter };
-                    var queryState = _parentPool is not null && Settings.ReplicationMode == ReplicationMode.Off;
-                    await connector.Open(timeout, async, queryState, cancellationToken);
+                    var queryClusterState = _parentPool is not null && Settings.ReplicationMode == ReplicationMode.Off;
+                    await connector.Open(timeout, async, queryClusterState, cancellationToken);
 
                     var i = 0;
                     for (; i < _max; i++)

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -1792,39 +1792,40 @@ namespace Npgsql
     public enum TargetSessionAttributes : byte
     {
         /// <summary>
-        ///  Try to connect to every server in order.
+        /// Any successful connection is acceptable.
         /// </summary>
         Any = 0,
 
         /// <summary>
-        ///  Secondary (readonly) server is selected for the connection.
+        /// Session must accept read-write transactions by default (that is, the server must not be in hot standby mode and the
+        /// <c>default_transaction_read_only</c> parameter must be off).
         /// </summary>
-        Secondary = 1,
+        ReadWrite = 1,
 
         /// <summary>
-        /// Secondary (readonly) server is selected for the connection. Falls back to Primary (writable), if none are available.
+        /// Session must not accept read-write transactions by default (the converse).
         /// </summary>
-        PreferSecondary = 2,
+        ReadOnly = 2,
 
         /// <summary>
-        ///  Primary (writable) server is selected for the connection.
+        /// Server must not be in hot standby mode.
         /// </summary>
         Primary = 3,
 
         /// <summary>
-        /// Primary (writable) server is selected for the connection. Falls back to Secondary (readonly), if none are available.
+        /// Server must be in hot standby mode.
         /// </summary>
-        PreferPrimary = 4,
+        Standby = 4,
 
         /// <summary>
-        /// Server must not be in hot standby mode and the default_transaction_read_only parameter must be 'off'.
+        /// First try to find a primary server, but if none of the listed hosts is a primary server, try again in <see cref="Any"/> mode.
         /// </summary>
-        ReadWrite = 5,
+        PreferPrimary = 5,
 
         /// <summary>
-        /// Server must be either in hot standby mode or the default_transaction_read_only parameter must be 'on'.
+        /// First try to find a standby server, but if none of the listed hosts is a standby server, try again in <see cref="Any"/> mode.
         /// </summary>
-        ReadOnly = 6,
+        PreferStandby = 6,
     }
 
     #endregion

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -438,7 +438,7 @@ namespace Npgsql
         /// </summary>
         /// <remarks>Usually called by the RequestConnector
         /// Method of the connection pool manager.</remarks>
-        internal async Task Open(NpgsqlTimeout timeout, bool async, bool queryState, CancellationToken cancellationToken)
+        internal async Task Open(NpgsqlTimeout timeout, bool async, bool queryClusterState, CancellationToken cancellationToken)
         {
             Debug.Assert(Connection != null && Connection.Connector == this);
             Debug.Assert(State == ConnectorState.Closed);
@@ -479,7 +479,7 @@ namespace Npgsql
                 }
 
                 await LoadDatabaseInfo(forceReload: false, timeout, async, cancellationToken);
-                if (queryState)
+                if (queryClusterState)
                     await QueryClusterState(timeout, async, cancellationToken);
 
                 if (Settings.Pooling && !Settings.Multiplexing && !Settings.NoResetOnClose && DatabaseInfo.SupportsDiscard)
@@ -577,10 +577,10 @@ namespace Npgsql
             Connection.ConnectorBindingScope = ConnectorBindingScope.PhysicalConnecting;
             using var _ = Defer(static (conn, prevScope) => conn.ConnectorBindingScope = prevScope, Connection, prevBindingScope);
 
-            using var cmd = new NpgsqlCommand("select pg_is_in_recovery();SHOW default_transaction_read_only;", Connection);
+            using var cmd = new NpgsqlCommand("select pg_is_in_recovery(); SHOW default_transaction_read_only", Connection);
             cmd.CommandTimeout = (int)timeout.CheckAndGetTimeLeft().TotalSeconds;
-            // We're taking the timestamp before the query is send, because due to issues (IO, operation ordering, etc) we can recieve an 'old' state
-            // Otherwise, execution of the query shouldn't make notable difference
+            // We're taking the timestamp before the query is sent, because due to issues (IO, operation ordering, etc) we can receive an
+            // 'old' state. Otherwise, execution of the query shouldn't make notable difference.
             var timeStamp = DateTime.UtcNow;
 
             using var reader = async ? await cmd.ExecuteReaderAsync(cancellationToken) : cmd.ExecuteReader();
@@ -590,7 +590,7 @@ namespace Npgsql
             reader.Read();
             var transactionReadOnly = reader.GetString(0) != "off";
 
-            var state = isInRecovery ? ClusterState.Secondary :
+            var state = isInRecovery ? ClusterState.Standby :
                 transactionReadOnly
                     ? ClusterState.PrimaryReadOnly
                     : ClusterState.PrimaryReadWrite;
@@ -840,7 +840,7 @@ namespace Npgsql
                     Log.Trace($"Failed to connect to {endpoint}", e);
 
                     if (i == endpoints.Length - 1)
-                        throw new NpgsqlException("Exception while connecting", e);
+                        throw new NpgsqlException($"Failed to connect to {endpoint}", e);
                 }
             }
         }
@@ -918,9 +918,7 @@ namespace Npgsql
                     Log.Trace($"Failed to connect to {endpoint}", e);
 
                     if (i == endpoints.Length - 1)
-                    {
-                        throw new NpgsqlException("Exception while connecting", e);
-                    }
+                        throw new NpgsqlException($"Failed to connect to {endpoint}", e);
                 }
                 finally
                 {

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -12,12 +12,12 @@ Npgsql.NpgsqlConnectionStringBuilder.TargetSessionAttributes.get -> Npgsql.Targe
 Npgsql.NpgsqlConnectionStringBuilder.TargetSessionAttributes.set -> void
 Npgsql.TargetSessionAttributes
 Npgsql.TargetSessionAttributes.Any = 0 -> Npgsql.TargetSessionAttributes
-Npgsql.TargetSessionAttributes.PreferPrimary = 4 -> Npgsql.TargetSessionAttributes
-Npgsql.TargetSessionAttributes.PreferSecondary = 2 -> Npgsql.TargetSessionAttributes
+Npgsql.TargetSessionAttributes.ReadWrite = 1 -> Npgsql.TargetSessionAttributes
+Npgsql.TargetSessionAttributes.ReadOnly = 2 -> Npgsql.TargetSessionAttributes
 Npgsql.TargetSessionAttributes.Primary = 3 -> Npgsql.TargetSessionAttributes
-Npgsql.TargetSessionAttributes.ReadOnly = 6 -> Npgsql.TargetSessionAttributes
-Npgsql.TargetSessionAttributes.ReadWrite = 5 -> Npgsql.TargetSessionAttributes
-Npgsql.TargetSessionAttributes.Secondary = 1 -> Npgsql.TargetSessionAttributes
+Npgsql.TargetSessionAttributes.Standby = 4 -> Npgsql.TargetSessionAttributes
+Npgsql.TargetSessionAttributes.PreferPrimary = 5 -> Npgsql.TargetSessionAttributes
+Npgsql.TargetSessionAttributes.PreferStandby = 6 -> Npgsql.TargetSessionAttributes
 NpgsqlTypes.NpgsqlTsQuery.Write(System.Text.StringBuilder! stringBuilder) -> void
 override NpgsqlTypes.NpgsqlTsQuery.Equals(object? obj) -> bool
 override NpgsqlTypes.NpgsqlTsQuery.GetHashCode() -> int

--- a/src/Npgsql/UnpooledConnectorSource.cs
+++ b/src/Npgsql/UnpooledConnectorSource.cs
@@ -21,7 +21,7 @@ namespace Npgsql
             NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
         {
             var connector = new NpgsqlConnector(conn, this);
-            await connector.Open(timeout, async, queryState: false, cancellationToken);
+            await connector.Open(timeout, async, queryClusterState: false, cancellationToken);
             Interlocked.Increment(ref _numConnectors);
             return connector;
         }

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Security;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Tests.Support;

--- a/test/Npgsql.Tests/MultipleHostsTests.cs
+++ b/test/Npgsql.Tests/MultipleHostsTests.cs
@@ -1,21 +1,216 @@
-﻿using NUnit.Framework;
+﻿using System;
+using System.Collections;
+using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using Npgsql.Tests.Support;
+using static Npgsql.Tests.TestUtil;
+using static Npgsql.Tests.Support.MockState;
 
 namespace Npgsql.Tests
 {
-    public class MultipleHostsTests : MultiplexingTestBase
+    public class MultipleHostsTests : TestBase
     {
-        public MultipleHostsTests(MultiplexingMode multiplexingMode) : base(multiplexingMode) { }
-
-        [Test, Timeout(10000), NonParallelizable]
-        public void Basic()
+        static readonly object[] MyCases =
         {
-            if (IsMultiplexing)
-                return;
+            new object[] { TargetSessionAttributes.Standby,       new[] { Primary,         Standby         }, 1 },
+            new object[] { TargetSessionAttributes.Standby,       new[] { PrimaryReadOnly, Standby         }, 1 },
+            new object[] { TargetSessionAttributes.PreferStandby, new[] { Primary,         Standby         }, 1 },
+            new object[] { TargetSessionAttributes.PreferStandby, new[] { PrimaryReadOnly, Standby         }, 1 },
+            new object[] { TargetSessionAttributes.PreferStandby, new[] { Primary,         Primary         }, 0 },
+            new object[] { TargetSessionAttributes.Primary,       new[] { Standby,         Primary         }, 1 },
+            new object[] { TargetSessionAttributes.Primary,       new[] { Standby,         PrimaryReadOnly }, 1 },
+            new object[] { TargetSessionAttributes.PreferPrimary, new[] { Standby,         Primary         }, 1 },
+            new object[] { TargetSessionAttributes.PreferPrimary, new[] { Standby,         PrimaryReadOnly }, 1 },
+            new object[] { TargetSessionAttributes.PreferPrimary, new[] { Standby,         Standby         }, 0 },
+            new object[] { TargetSessionAttributes.Any,           new[] { Standby,         Primary         }, 0 },
+            new object[] { TargetSessionAttributes.Any,           new[] { Primary,         Standby         }, 0 },
+            new object[] { TargetSessionAttributes.Any,           new[] { PrimaryReadOnly, Standby         }, 0 },
+            new object[] { TargetSessionAttributes.ReadWrite,     new[] { Standby,         Primary         }, 1 },
+            new object[] { TargetSessionAttributes.ReadWrite,     new[] { PrimaryReadOnly, Primary         }, 1 },
+            new object[] { TargetSessionAttributes.ReadOnly,      new[] { Primary,         Standby         }, 1 },
+            new object[] { TargetSessionAttributes.ReadOnly,      new[] { PrimaryReadOnly, Standby         }, 0 }
+        };
 
+        [Test]
+        [TestCaseSource(nameof(MyCases))]
+        public async Task Connect_to_correct_host(TargetSessionAttributes targetSessionAttributes, MockState[] servers, int expectedServer)
+        {
+            var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
+
+            var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+            {
+                Host = MultipleHosts(postmasters),
+                TargetSessionAttributes = targetSessionAttributes,
+                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+            };
+
+            using var pool = CreateTempPool(connectionStringBuilder, out var connectionString);
+            await using var conn = await OpenConnectionAsync(connectionString);
+
+            Assert.That(conn.Port, Is.EqualTo(postmasters[expectedServer].Port));
+
+            for (var i = 0; i <= expectedServer; i++)
+                _ = await postmasters[i].WaitForServerConnection();
+        }
+
+        [Test]
+        [TestCaseSource(nameof(MyCases))]
+        public async Task Connect_to_correct_host_with_available_idle(
+            TargetSessionAttributes targetSessionAttributes, MockState[] servers, int expectedServer)
+        {
+            var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
+
+            // First, open and close a connection with the TargetSessionAttributes matching the first server.
+            // This ensures wew have an idle connection in the pool.
+            var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+            {
+                Host = MultipleHosts(postmasters),
+                TargetSessionAttributes = servers[0] switch
+                {
+                    Primary => TargetSessionAttributes.ReadWrite,
+                    PrimaryReadOnly => TargetSessionAttributes.ReadOnly,
+                    Standby => TargetSessionAttributes.Standby,
+                    _ => throw new ArgumentOutOfRangeException()
+                },
+                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+            };
+
+            using var pool = CreateTempPool(connectionStringBuilder, out var connectionString);
+            await using (_ = await OpenConnectionAsync(connectionString))
+            {
+                // Do nothing, close to have an idle connection in the pool.
+            }
+
+            // Now connect with the test TargetSessionAttributes
+            connectionString = new NpgsqlConnectionStringBuilder(connectionString)
+            {
+                TargetSessionAttributes = targetSessionAttributes
+            }.ConnectionString;
+
+            await using var conn = await OpenConnectionAsync(connectionString);
+
+            Assert.That(conn.Port, Is.EqualTo(postmasters[expectedServer].Port));
+
+            for (var i = 0; i <= expectedServer; i++)
+                _ = await postmasters[i].WaitForServerConnection();
+        }
+
+        [Test]
+        [TestCase(TargetSessionAttributes.Standby,   new[] { Primary,         Primary })]
+        [TestCase(TargetSessionAttributes.Primary,   new[] { Standby,         Standby })]
+        [TestCase(TargetSessionAttributes.ReadWrite, new[] { PrimaryReadOnly, Standby })]
+        [TestCase(TargetSessionAttributes.ReadOnly,  new[] { Primary,         Primary })]
+        public async Task Valid_host_not_found(TargetSessionAttributes targetSessionAttributes, MockState[] servers)
+        {
+            var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
+
+            var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+            {
+                Host = MultipleHosts(postmasters),
+                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+                TargetSessionAttributes = targetSessionAttributes
+            };
+
+            using var pool = CreateTempPool(connectionStringBuilder.ConnectionString, out var connectionString);
+
+            var exception = Assert.ThrowsAsync<NpgsqlException>(async () => await OpenConnectionAsync(connectionString))!;
+            Assert.That(exception.Message, Is.EqualTo("No suitable host was found."));
+            Assert.That(exception.InnerException, Is.Null);
+
+            for (var i = 0; i < servers.Length; i++)
+                _ = await postmasters[i].WaitForServerConnection();
+        }
+
+        [Test]
+        public void All_hosts_are_down()
+        {
+            var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
+
+            using var socket1 = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            socket1.Bind(endpoint);
+            var localEndPoint1 = (IPEndPoint)socket1.LocalEndPoint!;
+
+            using var socket2 = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            socket2.Bind(endpoint);
+            var localEndPoint2 = (IPEndPoint)socket2.LocalEndPoint!;
+
+            // Note that we Bind (to reserve the port), but do not Listen - connection attempts will fail.
+
+            var connectionString = new NpgsqlConnectionStringBuilder
+            {
+                Host = $"{localEndPoint1.Address}:{localEndPoint1.Port},{localEndPoint2.Address}:{localEndPoint2.Port}"
+            }.ConnectionString;
+
+            var exception = Assert.ThrowsAsync<NpgsqlException>(async () => await OpenConnectionAsync(connectionString))!;
+            var aggregateException = (AggregateException)exception.InnerException!;
+            Assert.That(aggregateException.InnerExceptions, Has.Count.EqualTo(2));
+
+            for (var i = 0; i < aggregateException.InnerExceptions.Count; i++)
+            {
+                Assert.That(aggregateException.InnerExceptions[i], Is.TypeOf<NpgsqlException>()
+                    .With.InnerException.TypeOf<SocketException>()
+                    .With.InnerException.Property(nameof(SocketException.SocketErrorCode)).EqualTo(SocketError.ConnectionRefused));
+            }
+        }
+
+        [Test]
+        public async Task First_host_is_down()
+        {
+            using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
+            socket.Bind(endpoint);
+            var localEndPoint = (IPEndPoint)socket.LocalEndPoint!;
+            // Note that we Bind (to reserve the port), but do not Listen - connection attempts will fail.
+
+            await using var postmaster = PgPostmasterMock.Start(state: Primary);
+
+            var connectionString = new NpgsqlConnectionStringBuilder
+            {
+                Host = $"{localEndPoint.Address}:{localEndPoint.Port},{postmaster.Host}:{postmaster.Port}",
+                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading
+            }.ConnectionString;
+
+            await using var conn = await OpenConnectionAsync(connectionString);
+            Assert.That(conn.Port, Is.EqualTo(postmaster.Port));
+        }
+
+        [Test]
+        public async Task TargetSessionAttributes_with_single_host([Values] TargetSessionAttributes targetSessionAttributes)
+        {
+            var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
+            {
+                TargetSessionAttributes = targetSessionAttributes
+            }.ConnectionString;
+
+            if (targetSessionAttributes == TargetSessionAttributes.Any)
+            {
+                await using var postmasterMock = PgPostmasterMock.Start(ConnectionString);
+                using var pool = CreateTempPool(postmasterMock.ConnectionString, out connectionString);
+                await using var conn = await OpenConnectionAsync(connectionString);
+                _ = await postmasterMock.WaitForServerConnection();
+            }
+            else
+            {
+                Assert.That(() => OpenConnectionAsync(connectionString), Throws.Exception.TypeOf<NotSupportedException>());
+            }
+        }
+
+        [Test]
+        public void TargetSessionAttributes_default_is_Any()
+        {
+            var builder = new NpgsqlConnectionStringBuilder();
+            Assert.That(builder.TargetSessionAttributes, Is.EqualTo(TargetSessionAttributes.Any));
+        }
+
+        // This is the only test in this class which actually connects to PostgreSQL (the others use the PostgreSQL mock)
+        [Test, Timeout(10000), NonParallelizable]
+        public void IntegrationTest()
+        {
             PoolManager.Reset();
 
             var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
@@ -31,14 +226,14 @@ namespace Npgsql.Tests
                 Client(csb, TargetSessionAttributes.Any),
                 Client(csb, TargetSessionAttributes.Primary),
                 Client(csb, TargetSessionAttributes.PreferPrimary),
-                Client(csb, TargetSessionAttributes.PreferSecondary),
+                Client(csb, TargetSessionAttributes.PreferStandby),
                 Client(csb, TargetSessionAttributes.ReadWrite));
 
-            var onlySecondaryClient = Client(csb, TargetSessionAttributes.Secondary);
+            var onlyStandbyClient = Client(csb, TargetSessionAttributes.Standby);
             var readOnlyClient = Client(csb, TargetSessionAttributes.ReadOnly);
 
             Assert.DoesNotThrowAsync(async () => await clientsTask);
-            Assert.ThrowsAsync<NpgsqlException>(async () => await onlySecondaryClient);
+            Assert.ThrowsAsync<NpgsqlException>(async () => await onlyStandbyClient);
             Assert.ThrowsAsync<NpgsqlException>(async () => await readOnlyClient);
             Assert.AreEqual(125, queriesDone);
 
@@ -72,5 +267,8 @@ namespace Npgsql.Tests
                 }
             }
         }
+
+        static string MultipleHosts(params PgPostmasterMock[] postmasters)
+            => string.Join(",", postmasters.Select(p => $"{p.Host}:{p.Port}"));
     }
 }


### PR DESCRIPTION
Also see test failures and TODO comments:

* ~Support host:port syntax without multiple hosts (consistency)~
* ~TargetSessionAttributes but no multiple hosts: make Any work, throw NotSupportedException otherwise?~
* Test First_host_is_down fails, because the first attempt fails (as part of the test), and the connector is Broken, setting the connection's state to Broken as well - and that prevents the second attempt from working properly. We should probably not set the connection state's to Broken for Open attempts.
